### PR TITLE
Force add incase gitignore and fix exits on warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -503,7 +503,7 @@ module.exports = {
              options.imageDirectory, '--build-report=true']).then(function (params) {
                if (prNumber === false) {
                  console.log('Git add')
-                 return runCommand('git', ['add', '-A', options.imageDirectory]).then(function (params) {
+                 return runCommand('git', ['add', '-f', '-A', options.imageDirectory]).then(function (params) {
                    console.log('Git commit')
                    return runCommand('git', ['commit', '-m',
                     '"Adding new baseline images [ci skip]"']).then(function (params) {
@@ -535,7 +535,7 @@ module.exports = {
             return runCommand('ember', ['new-baseline', '--image-directory=' +
              options.imageDirectory]).then(function (params) {
                console.log('Git add')
-               return runCommand('git', ['add', '-A', options.imageDirectory]).then(function (params) {
+               return runCommand('git', ['add', '-f', '-A', options.imageDirectory]).then(function (params) {
                  console.log('Git commit')
                  return runCommand('git', ['commit', '-m',
                   '"Adding new baseline images [ci skip]"']).then(function (params) {
@@ -615,7 +615,7 @@ module.exports = {
              options.imageDirectory]).then(function (params) {
                if (prNumber === false) {
                  console.log('Git add')
-                 return runCommand('git', ['add', '-A', options.imageDirectory]).then(function (params) {
+                 return runCommand('git', ['add', '-f', '-A', options.imageDirectory]).then(function (params) {
                    console.log('Git commit')
                    return runCommand('git', ['commit', '-m',
                     '"Adding new baseline images [ci skip]"']).then(function (params) {
@@ -637,7 +637,7 @@ module.exports = {
             return runCommand('ember', ['new-baseline', '--image-directory=' +
              options.imageDirectory]).then(function (params) {
                console.log('Git add')
-               return runCommand('git', ['add', '-A', options.imageDirectory]).then(function (params) {
+               return runCommand('git', ['add', '-f', '-A', options.imageDirectory]).then(function (params) {
                  console.log('Git commit')
                  return runCommand('git', ['commit', '-m',
                   '"Adding new baseline images [ci skip]"']).then(function (params) {

--- a/index.js
+++ b/index.js
@@ -34,16 +34,16 @@ function runCommand (command, args, ignoreStdError) {
       console.log(data.toString())
     })
     child.stderr.on('data', function (data) {
-      if (ignoreStdError || data.toString().indexOf('fs: re-evaluating native module sources is not supported.') > -1) {
-        // Use ignoreStdError only to get around this issue https://github.com/ciena-blueplanet/ember-cli-visual-acceptance/issues/25
-        console.log(data.toString())
-      } else {
-        reject(data.toString())
-      }
+      console.error(data.toString())
     })
 
     child.on('exit', function (code) {
-      resolve()
+      console.log('Exit with code ' + code)
+      if (code === 0) {
+        resolve()
+      } else {
+        reject()
+      }
     })
   })
 }


### PR DESCRIPTION
#patch#

Only question is if we want to use chalk or something similar to print out errors in color. I tried octo literals to color but apparently those aren't allowed in strict mode

Fixes: https://github.com/ciena-blueplanet/ember-cli-visual-acceptance/issues/27 , https://github.com/ciena-blueplanet/ember-cli-visual-acceptance/issues/25