### PR TITLE
Make size default and targeted element default size be reflected in dir

### DIFF
--- a/vendor/VisualAcceptance.js
+++ b/vendor/VisualAcceptance.js
@@ -96,7 +96,7 @@ function capture (imageName, options) {
     browserDirectory += options.width + 'x' + options.height + '/'
   } else {
     // default mocha window size
-    browserDirectory += options.targetElement.clientWidth + 'x' + options.targetElement.clientHeight + '/'
+    browserDirectory += 'default/'
   }
   // resemble.outputSettings({
   //   largeImageThreshold: 0


### PR DESCRIPTION
#patch#

# Changelog
* Make the directory `default/` rather than '`<element-width>x<element-height>/`. This does not affect elements where the size is specified.
  * This will help scenarios where targeted element show up as `New` rather than `Changed` simply b/c the size of the target changed.
  *  Also it's easier to navigate instead of having to open every folder to see where the target element is located