### PR TITLE
Chrome on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ before_script:
 - "sh -e /etc/init.d/xvfb start"
 - sleep 3 # give xvfb some time to start
 script:
+- echo $CHROME_BIN
 - testem launchers
 - npm run lint && ember tva
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,7 @@ branches:
   except:
   - /^v[0-9\.]+/
 before_install:
-- export CHROME_BIN=chromium-browser
-- npm install -g coveralls pr-bumper slimerjs phantomjs testem
+- npm install -g coveralls pr-bumper slimerjs phantomjs
 - pr-bumper check
 - slimerjs -v
 before_script:
@@ -21,8 +20,6 @@ before_script:
 - "sh -e /etc/init.d/xvfb start"
 - sleep 3 # give xvfb some time to start
 script:
-- echo $CHROME_BIN
-- testem launchers
 - npm run lint && ember tva
 install:
 - npm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ branches:
   except:
   - /^v[0-9\.]+/
 before_install:
-- npm install -g coveralls pr-bumper slimerjs phantomjs
+- export CHROME_BIN=chromium-browser
+- npm install -g coveralls pr-bumper slimerjs phantomjs testem
 - pr-bumper check
 - slimerjs -v
 before_script:
@@ -20,6 +21,7 @@ before_script:
 - "sh -e /etc/init.d/xvfb start"
 - sleep 3 # give xvfb some time to start
 script:
+- testem launchers
 - npm run lint && ember tva
 install:
 - npm install

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ capture (imageName, options)
 | options.height                   | number | null                | Define the height of the canvas in pixels. If null, renders with full height of the targetElement. |
 | options.misMatchPercentageMargin                 | float  | 0.00                | The maximum percentage ResembleJs is allowed to misMatch. |
 | options.targetElement            | HTMLElement | ember-testing-container       | DOM element to capture (Most likely want to set `height` and `width` to null, so we don't overwrite the element's height and width )|
-| options.experimentalSvgs         | boolean  | undefined                | Set to true in order try experimental rendering of svgs using html2canvas.|
+| options.experimentalSvgs         | boolean  | undefined                | Set to true in order try experimental rendering of svgs using html2canvas. (Used only on Firefox. Chrome canvas drawing support handles svgs)|
 | options.assert                   | object  | undefined                | Only use to pass in **Qunit** `assert` object.|
 
 

--- a/testem.js
+++ b/testem.js
@@ -5,7 +5,8 @@ module.exports = {
   'launch_in_ci': [
     'Firefox',
     'SlimerJsVisualAcceptance',
-    'PhantomJsVisualAcceptance'
+    'PhantomJsVisualAcceptance',
+    'Chrome'
   ],
   'launch_in_dev': [
     'Firefox'

--- a/testem.js
+++ b/testem.js
@@ -6,7 +6,7 @@ module.exports = {
     'Firefox',
     'SlimerJsVisualAcceptance',
     'PhantomJsVisualAcceptance',
-    'Chrome'
+    'Chromium'
   ],
   'launch_in_dev': [
     'Firefox'

--- a/tests/integration/simple-test.js
+++ b/tests/integration/simple-test.js
@@ -36,6 +36,7 @@ describeComponent(
       })
     })
     it('renders svg', function (done) {
+      this.timeout(5000)
       /* eslint-disable max-len */
       this.render(hbs `<svg id="mySVG"xmlns="http://www.w3.org/2000/svg" viewBox="-350 -250 700 500">
       <style type="text/css" media="screen">
@@ -57,6 +58,7 @@ describeComponent(
     })
 
     it('renders svg experimental', function (done) {
+      this.timeout(5000)
       /* eslint-disable max-len */
       this.render(hbs `<svg id="mySVG"xmlns="http://www.w3.org/2000/svg" viewBox="-350 -250 700 500">
       <style type="text/css" media="screen">

--- a/tests/integration/simple-test.js
+++ b/tests/integration/simple-test.js
@@ -26,6 +26,7 @@ describeComponent(
       })
     })
     it('renders something else', function (done) {
+      this.timeout(5000)      
       this.render(hbs `<div id='test'>Test Else</div>`)
       expect(this.$()).to.have.length(1)
       capture('Error').then(function (data) {
@@ -80,6 +81,7 @@ describeComponent(
     })
 
     it('captures target', function (done) {
+      this.timeout(5000)      
       /* eslint-disable max-len */
       this.render(hbs `<div class="outer">
     <div class="innerdivs left">

--- a/tests/integration/simple-test.js
+++ b/tests/integration/simple-test.js
@@ -26,7 +26,7 @@ describeComponent(
       })
     })
     it('renders something else', function (done) {
-      this.timeout(5000)      
+      this.timeout(5000)
       this.render(hbs `<div id='test'>Test Else</div>`)
       expect(this.$()).to.have.length(1)
       capture('Error').then(function (data) {
@@ -81,7 +81,7 @@ describeComponent(
     })
 
     it('captures target', function (done) {
-      this.timeout(5000)      
+      this.timeout(5000)
       /* eslint-disable max-len */
       this.render(hbs `<div class="outer">
     <div class="innerdivs left">

--- a/vendor/VisualAcceptance.js
+++ b/vendor/VisualAcceptance.js
@@ -105,7 +105,7 @@ function capture (imageName, options) {
     return capturePhantom(imageName, options.width, options.height,
      options.misMatchPercentageMargin, options.targetElement, options.assert, browserDirectory)
   } else {
-    if (options.experimentalSvgs === true) {
+    if (options.experimentalSvgs === true && browser.browser !== 'Chrome') {
       return experimentalSvgCapture().then(function () {
         return captureHtml2Canvas(imageName, options.width, options.height,
          options.misMatchPercentageMargin, options.targetElement,
@@ -300,6 +300,8 @@ function utilizeImage (imageName, width, height, misMatchPercentageMargin, targe
       })
     }).then(function (data) {
       data ? resolve(data) : reject(data)
+    }).catch(function (err) {
+      reject(err)
     })
   }
 }


### PR DESCRIPTION
#patch#
Also includes fix for chrome. Plus ignore svgExperimental on Chrome cause it works.


Only downside is you have to use `Chromium` in Testem rather than `Chrome`. So you have to remove it on Mac OS X. But totally worth it for Chrome on Travis