### PR TITLE
Fix `ember new-baseline`. Deletes current OS baseline. Not all

### DIFF
--- a/lib/commands/new-baseline.js
+++ b/lib/commands/new-baseline.js
@@ -20,11 +20,26 @@ module.exports = {
     type: Boolean,
     default: false,
     description: 'Wheter or not to build a report'
+  }, {
+    name: 'delete-all',
+    type: Boolean,
+    default: false,
+    description: 'Delete entire visual-acceptance folder, rather than just current OS'
   }],
   run: function (options, rawArgs) {
     var root = this.project.root
-
-    deleteFolderRecursive(path.join(root, options.imageDirectory))
+    var imageDirectory = options.imageDirectory
+    if (!options.deleteAll) {
+      var platform = process.platform
+      if (/^linux/.test(platform)) {
+        imageDirectory = path.join(imageDirectory, 'Linux')
+      } else if (/^darwin/.test(platform)) {
+        imageDirectory = path.join(imageDirectory, 'Mac OS X')
+      } else if (/^win32/.test(platform)) {
+        imageDirectory = path.join(imageDirectory, 'Windows')
+      }
+    }
+    deleteFolderRecursive(path.join(root, imageDirectory))
     return runCommand(this, options.buildReport ? 'br' : 'test', rawArgs)
   }
 }


### PR DESCRIPTION
#minor#

# Changelog
* Rather than deleting the entire folder when doing `ember new-baseline`, now only deletes current OS
  * `--delete-all` option added to delete entire  visual acceptance folder
  * This will help when doing Multi-OS https://docs.travis-ci.com/user/multi-os/
    * Although user will have to pull before they run `ember tva` in this scenario (since Linux will push. Than Mac will push) Fun race conditions