### PR TITLE
Get rid of bower

### DIFF
--- a/blueprints/ember-cli-visual-acceptance/index.js
+++ b/blueprints/ember-cli-visual-acceptance/index.js
@@ -1,30 +1,14 @@
 module.exports = {
   description: 'Add resemble to bower html2canvas to bower',
 
-  // locals: function(options) {
-  //   // Return custom template variables here.
-  //   return {
-  //     foo: options.entity.options.foo
-  //   };
-  // }
-  included: function (app) {
-    this._super.included(app)
-    app.import(app.bowerDirectory + '/resemblejs/resemble.js', {
-      type: 'test'
-    })
-  },
   normalizeEntityName: function () {
     // no-op
   },
+
   afterInstall: function (options) {
     // Perform extra work here.
-    var that = this
-    return this.addBowerPackageToProject('es6-promise').then(function (params) {
-      return that.addBowerPackageToProject('resemblejs').then(function (params) {
-        return that.insertIntoFile('.gitignore', '/visual-acceptance').then(function (params) {
-          return that.insertIntoFile('.npmignore', '/visual-acceptance')
-        })
-      })
-    })
+    return this.insertIntoFile('.gitignore', '/visual-acceptance').then(function (params) {
+      return this.insertIntoFile('.npmignore', '/visual-acceptance')
+    }.bind(this))
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -5,12 +5,10 @@
     "ember-cli-shims": "0.1.1",
     "ember-cli-test-loader": "0.2.2",
     "ember-qunit-notifications": "0.1.0",
-    "resemblejs": "2.2.0",
     "mocha": "~2.2.4",
     "ember-mocha-adapter": "~0.3.1",
     "sinonjs": "^1.17.1",
-    "chai": "~2.3.0",
-    "es6-promise": "^3.2.2"
+    "chai": "~2.3.0"
   },
   "resolutions": {
     "chai": "~2.3.0"

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -10,8 +10,6 @@ module.exports = function (defaults) {
   })
 
   app.import('bower_components/sinonjs/sinon.js')
-  app.import('vendor/html2canvas.js', {type: 'test'})
-  app.import('vendor/VisualAcceptance.js', {type: 'test'})
   /*
     This build file specifies the options for the dummy test app of this
     addon, located in `/tests/dummy`

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -12,9 +12,6 @@ module.exports = function (defaults) {
   app.import('bower_components/sinonjs/sinon.js')
   app.import('vendor/html2canvas.js', {type: 'test'})
   app.import('vendor/VisualAcceptance.js', {type: 'test'})
-  app.import('bower_components/es6-promise/es6-promise.js', {
-    type: 'test'
-  })
   /*
     This build file specifies the options for the dummy test app of this
     addon, located in `/tests/dummy`

--- a/index.js
+++ b/index.js
@@ -175,18 +175,19 @@ module.exports = {
 
   options: {
     nodeAssets: {
-      resemblejs: function () {
-        return {
-          enabled: this.app.env !== 'production',
-          import: ['resemble.js']
-        }
+      resemblejs: {
+        import: [{
+          path: 'resemble.js',
+          type: 'test'
+        }]
       },
-      'es6-promise': function () {
-        return {
-          enabled: this.app.env !== 'production',
-          srcDir: 'dist',
-          import: ['es6-promise.min.js']
-        }
+      'es6-promise': {
+        srcDir: 'dist',
+        import: [{
+          path: 'es6-promise.js',
+          sourceMap: 'es6-promise.map',
+          type: 'test'
+        }]
       }
     }
   },

--- a/index.js
+++ b/index.js
@@ -175,18 +175,27 @@ module.exports = {
 
   options: {
     nodeAssets: {
-      resemblejs: {
-        import: ['resemble.js']
+      resemblejs: function () {
+        return {
+          enabled: this.app.env !== 'production',
+          import: ['resemble.js']
+        }
       },
-      'es6-promise': {
-        srcDir: 'dist',
-        import: ['es6-promise.js']
+      'es6-promise': function () {
+        return {
+          enabled: this.app.env !== 'production',
+          srcDir: 'dist',
+          import: ['es6-promise.min.js']
+        }
       }
     }
   },
 
   included: function (app) {
     this._super.included.apply(this, arguments)
+
+    this.app = app
+
     if (app) {
       app.import(path.join('vendor', 'html2canvas.js'), {
         type: 'test'

--- a/index.js
+++ b/index.js
@@ -168,15 +168,26 @@ function getImage (req, res, options) {
 
 module.exports = {
   name: 'ember-cli-visual-acceptance',
+
+  imageDirectory: 'visual-acceptance',
+
+  targetBrowsers: [],
+
+  options: {
+    nodeAssets: {
+      resemblejs: {
+        import: ['resemble.js']
+      },
+      'es6-promise': {
+        srcDir: 'dist',
+        import: ['es6-promise.js']
+      }
+    }
+  },
+
   included: function (app) {
-    this._super.included(app)
+    this._super.included.apply(this, arguments)
     if (app) {
-      app.import(app.bowerDirectory + '/resemblejs/resemble.js', {
-        type: 'test'
-      })
-      app.import(app.bowerDirectory + '/es6-promise/es6-promise.js', {
-        type: 'test'
-      })
       app.import(path.join('vendor', 'html2canvas.js'), {
         type: 'test'
       })
@@ -196,8 +207,7 @@ module.exports = {
       this.targetBrowsers = app.options.visualAcceptanceOptions.targetBrowsers || []
     }
   },
-  imageDirectory: 'visual-acceptance',
-  targetBrowsers: [],
+
   middleware: function (app, options) {
     app.use(bodyParser.urlencoded({
       limit: '50mb',

--- a/package.json
+++ b/package.json
@@ -48,7 +48,9 @@
     "body-parser": "^1.15.1",
     "chalk": "^1.1.3",
     "ember-cli-babel": "^5.1.6",
+    "ember-cli-node-assets": "^0.1.4",
     "resemblejs": "^2.2.0",
+    "es6-promise": "^3.2.2",
     "sync-request": "^3.0.1"
   },
   "ember-addon": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "chalk": "^1.1.3",
     "ember-cli-babel": "^5.1.6",
     "ember-cli-node-assets": "^0.1.4",
-    "resemblejs": "^2.2.0",
+    "resemblejs": "2.2.0",
     "es6-promise": "^3.2.2",
     "sync-request": "^3.0.1"
   },


### PR DESCRIPTION
#minor#

Here I've used [ember-cli-node-assets](https://github.com/dfreeman/ember-cli-node-assets) to replace bower deps with node packages.

It allows a consumer app to skip `bower install` step. 

# CHANGELOG

* Replaced resemble and es6-promise bower dependencies with npm dependencies