### PR TITLE
Fix RSVP module reference

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,7 +3,7 @@
 var fs = require('fs')
 var path = require('path')
 var spawn = require('child_process').spawn
-var RSVP = require('rsvp')
+var Promise = require('es6-promise').Promise
 var chalk = require('chalk')
 var lookupCommand = require('ember-cli/lib/cli/lookup-command')
 
@@ -37,7 +37,7 @@ function mkdirpSync (dirpath) {
 }
 
 function runExecutable (command, args, ignoreStdError) {
-  return new RSVP.Promise(function (resolve, reject) {
+  return new Promise(function (resolve, reject) {
     var child = spawn(command, args, {
       env: process.env
     })


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #none# - documentation fixes and/or test additions
 - [x] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG
- Fixes https://github.com/ciena-blueplanet/ember-cli-visual-acceptance/issues/103
- Fix RSVP reference and switch to `var Promise = require('es6-promise').Promise`
