### PR TITLE
Remove '.tabs' check since no longer an element & can conflict with application class usage

### DIFF
--- a/vendor/VisualAcceptance.js
+++ b/vendor/VisualAcceptance.js
@@ -255,7 +255,7 @@ function captureHtml2Canvas (imageName, width, height, misMatchPercentageMargin,
  */
 function utilizeImage (imageName, width, height, misMatchPercentageMargin, targetElement, assert,
  image, browserDirectory, resolve, reject) {
-  if (!document.getElementById('visual-acceptance') && $('.tabs').length === 0) {
+  if (!document.getElementById('visual-acceptance')) {
     var visualAcceptanceContainer
     visualAcceptanceContainer = document.createElement('div')
     visualAcceptanceContainer.setAttribute('id', 'visual-acceptance')


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #none# - documentation fixes and/or test additions
 - [x] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG
- Fixes issue with checking no longer used `.tabs` class, that conflicts with user apps that make use of this addon